### PR TITLE
fix(tests): correct stale test expectations in novels and accounts

### DIFF
--- a/novelapp/accounts/tests.py
+++ b/novelapp/accounts/tests.py
@@ -33,16 +33,14 @@ class AuthenticationTests(TestCase):
         self.assertTemplateUsed(response, 'accounts/register.html')
 
     def test_registration_functionality(self):
-        response = self.client.post(reverse('register'), {
-            'username': 'newuser',
-            'password': 'newpassword123',
-            'password_confirm': 'newpassword123' # Standard UserCreationForm fields? No, it's password1 and password2
-        }, follow=True) # UserCreationForm fields are usually username, password1, password2
-        # Let's check the form or just use valid data
+        # UserRegistrationForm extends UserCreationForm with a required
+        # email field, and register_view redirects to login (not dashboard)
+        # on success -- there's no auto-login after registration.
         response = self.client.post(reverse('register'), {
             'username': 'newuser2',
+            'email': 'newuser2@example.com',
             'password1': 'newpassword123',
             'password2': 'newpassword123'
         })
-        self.assertRedirects(response, reverse('dashboard'))
+        self.assertRedirects(response, reverse('login'))
         self.assertTrue(User.objects.filter(username='newuser2').exists())

--- a/novelapp/novels/tests.py
+++ b/novelapp/novels/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
-from .models import Novel, Chapter, Scene
+from .models import Novel, Part, Chapter, Scene
 
 class NovelScopingTests(TestCase):
     def setUp(self):
@@ -30,7 +30,11 @@ class WordCountTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username='testuser', password='pass')
         self.novel = Novel.objects.create(user=self.user, title='Test Novel')
-        self.chapter = Chapter.objects.create(novel=self.novel, title='Chapter 1', order=1)
+        # Chapter has no direct FK to Novel -- it hangs off Part. Chapter.novel
+        # is a derived read-only property (part.novel), so a Part has to exist
+        # first even though parts_enabled is off for this novel.
+        self.part = Part.objects.create(novel=self.novel, title='Part 1', order=1)
+        self.chapter = Chapter.objects.create(part=self.part, title='Chapter 1', order=1)
         self.scene = Scene.objects.create(chapter=self.chapter, title='Scene 1', order=1)
 
     def test_word_count_calculation(self):


### PR DESCRIPTION
- WordCountTests.setUp() now creates a Part before the Chapter, since Chapter has no direct FK to Novel (Chapter.novel is a derived read-only property via part.novel)
- test_registration_functionality now includes the required email field and expects a redirect to login, matching register_view's actual behaviour (no auto-login after registration)