### PR TITLE
test(scaffolding): add pytest-django scaffolding against Postgres

### DIFF
--- a/novelapp/accounts/factories.py
+++ b/novelapp/accounts/factories.py
@@ -1,0 +1,12 @@
+import factory
+from django.contrib.auth.models import User
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = User
+        django_get_or_create = ('username',)
+
+    username = factory.Sequence(lambda n: f'testuser{n}')
+    email = factory.LazyAttribute(lambda o: f'{o.username}@example.com')
+    password = factory.PostGenerationMethodCall('set_password', 'testpass123')

--- a/novelapp/novelapp/settings_test.py
+++ b/novelapp/novelapp/settings_test.py
@@ -1,12 +1,31 @@
+"""
+Test settings for Novel-It.
+
+Inherits everything from the main settings module except where overridden
+below. In particular, DATABASES stays pointed at Postgres (via the same
+DATABASE_URL read in .env) rather than SQLite, because SQLite silently
+masks bulk-UPDATE ordering issues that Postgres's query planner does not
+-- exactly the class of bug already found in the reorder views.
+
+Django's test runner creates and destroys a disposable `test_<name>`
+database on the same Postgres server automatically for each run -- it
+never touches the real dev database. This requires the DATABASE_URL role
+to have CREATEDB privilege; see project notes for the check/grant command.
+"""
+
 from .settings import *
 
-# Override SECRET_KEY for testing
+# Override SECRET_KEY for testing -- never used outside test runs.
 SECRET_KEY = 'test-secret-key-for-ci-cd-testing-only-not-for-production'
 
+# Run tests closer to production behaviour (also matches how the app is
+# actually deployed, rather than the DEBUG=True dev default).
+DEBUG = False
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'test_db.sqlite3',
-    }
-}
+# Speed up user-creation-heavy tests -- characters, locations, items all
+# scope to a user, so many tests create one. Hasher security doesn't
+# matter for throwaway test data.
+PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
+
+# No lingering connections between short-lived test runs.
+DATABASES['default']['CONN_MAX_AGE'] = 0

--- a/novelapp/novels/factories.py
+++ b/novelapp/novels/factories.py
@@ -1,0 +1,45 @@
+import factory
+from accounts.factories import UserFactory
+from .models import Novel, Part, Chapter, Scene
+
+
+class NovelFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Novel
+
+    user = factory.SubFactory(UserFactory)
+    title = factory.Sequence(lambda n: f'Test Novel {n}')
+
+
+class PartFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Part
+
+    novel = factory.SubFactory(NovelFactory)
+    title = factory.Sequence(lambda n: f'Part {n}')
+    # Sequence is global across all Part instances, not per-novel, so this
+    # never collides with the novel+order unique_together constraint even
+    # when several Parts are created against the same novel.
+    order = factory.Sequence(lambda n: n)
+
+
+class ChapterFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Chapter
+
+    # Chapter has no direct FK to Novel -- it hangs off Part. Use
+    # ChapterFactory(part=PartFactory(novel=my_novel)) to place a chapter
+    # under a specific novel.
+    part = factory.SubFactory(PartFactory)
+    title = factory.Sequence(lambda n: f'Chapter {n}')
+    order = factory.Sequence(lambda n: n)
+
+
+class SceneFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Scene
+
+    chapter = factory.SubFactory(ChapterFactory)
+    title = factory.Sequence(lambda n: f'Scene {n}')
+    order = factory.Sequence(lambda n: n)
+    content = factory.Faker('paragraph', nb_sentences=5)

--- a/novelapp/novels/test_factories.py
+++ b/novelapp/novels/test_factories.py
@@ -1,0 +1,28 @@
+import pytest
+from .factories import NovelFactory, PartFactory, ChapterFactory, SceneFactory
+
+
+@pytest.mark.django_db
+def test_scene_factory_builds_full_chain():
+    """NovelFactory/PartFactory/ChapterFactory/SceneFactory should chain
+    together into a valid Novel -> Part -> Chapter -> Scene hierarchy."""
+    scene = SceneFactory()
+    assert scene.pk is not None
+    assert scene.chapter.pk is not None
+    assert scene.chapter.part.pk is not None
+    assert scene.chapter.part.novel.pk is not None
+    assert scene.chapter.novel == scene.chapter.part.novel
+
+
+@pytest.mark.django_db
+def test_part_and_chapter_order_sequence_avoids_collisions():
+    """Multiple Parts/Chapters against the same parent shouldn't collide
+    with the (novel, order) / (part, order) unique_together constraints."""
+    novel = NovelFactory()
+    part1 = PartFactory(novel=novel)
+    part2 = PartFactory(novel=novel)
+    assert part1.order != part2.order
+
+    chapter1 = ChapterFactory(part=part1)
+    chapter2 = ChapterFactory(part=part1)
+    assert chapter1.order != chapter2.order

--- a/novelapp/planning/factories.py
+++ b/novelapp/planning/factories.py
@@ -1,0 +1,85 @@
+import factory
+from novels.factories import NovelFactory
+from .models import (
+    CharacterRole, LocationType, ItemType, WorldBuildingType,
+    Character, Location, Item, WorldBuilding,
+)
+
+
+# --- User-definable choice models ---
+#
+# These are scoped to a novel (unique_together = ['novel', 'name']). If a
+# Character/Location/Item/WorldBuilding needs a role/type from the SAME
+# novel it belongs to, pass novel explicitly to both, e.g.:
+#
+#   novel = NovelFactory()
+#   role = CharacterRoleFactory(novel=novel)
+#   character = CharacterFactory(novel=novel, role=role)
+#
+# Left unspecified, each SubFactory below creates its own independent
+# novel, which is fine when the test doesn't care about role/type scoping.
+
+class CharacterRoleFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = CharacterRole
+
+    novel = factory.SubFactory(NovelFactory)
+    name = factory.Sequence(lambda n: f'Role {n}')
+
+
+class LocationTypeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = LocationType
+
+    novel = factory.SubFactory(NovelFactory)
+    name = factory.Sequence(lambda n: f'Location Type {n}')
+
+
+class ItemTypeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ItemType
+
+    novel = factory.SubFactory(NovelFactory)
+    name = factory.Sequence(lambda n: f'Item Type {n}')
+
+
+class WorldBuildingTypeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = WorldBuildingType
+
+    novel = factory.SubFactory(NovelFactory)
+    name = factory.Sequence(lambda n: f'World Building Type {n}')
+
+
+# --- Main planning models ---
+
+class CharacterFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Character
+
+    novel = factory.SubFactory(NovelFactory)
+    fullname = factory.Faker('name')
+
+
+class LocationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Location
+
+    novel = factory.SubFactory(NovelFactory)
+    name = factory.Faker('city')
+
+
+class ItemFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Item
+
+    novel = factory.SubFactory(NovelFactory)
+    name = factory.Sequence(lambda n: f'Item {n}')
+
+
+class WorldBuildingFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = WorldBuilding
+
+    novel = factory.SubFactory(NovelFactory)
+    name = factory.Sequence(lambda n: f'World Building Item {n}')

--- a/novelapp/planning/test_factories.py
+++ b/novelapp/planning/test_factories.py
@@ -1,0 +1,22 @@
+import pytest
+from novels.factories import NovelFactory
+from .factories import CharacterRoleFactory, CharacterFactory, LocationFactory, ItemFactory, WorldBuildingFactory
+
+
+@pytest.mark.django_db
+def test_planning_factories_build_independently():
+    assert CharacterFactory().pk is not None
+    assert LocationFactory().pk is not None
+    assert ItemFactory().pk is not None
+    assert WorldBuildingFactory().pk is not None
+
+
+@pytest.mark.django_db
+def test_character_with_role_in_same_novel():
+    """Role and Character need the same novel passed explicitly -- this
+    confirms that pattern actually works end-to-end."""
+    novel = NovelFactory()
+    role = CharacterRoleFactory(novel=novel)
+    character = CharacterFactory(novel=novel, role=role)
+    assert character.role == role
+    assert character.novel == role.novel

--- a/novelapp/pytest.ini
+++ b/novelapp/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = novelapp.settings_test
+python_files = tests.py test_*.py *_tests.py

--- a/novelapp/requirements.txt
+++ b/novelapp/requirements.txt
@@ -9,3 +9,6 @@ whitenoise>=6.0
 behave==1.3.3
 git+https://github.com/behave/behave-django.git@main
 selenium==4.16.0
+pytest==9.1.1
+pytest-django==4.14.0
+factory_boy==3.3.3


### PR DESCRIPTION
- settings_test.py now inherits Postgres DATABASES from settings.py instead of SQLite, so bulk-UPDATE ordering behaviour matches production
- pytest.ini wires DJANGO_SETTINGS_MODULE to settings_test
- factory_boy factories for the Novel/Part/Chapter/Scene hierarchy and the Character/Location/Item/World Building planning models
- smoke tests confirming the factories build a valid chain and don't collide on unique_together(order) constraints
- pytest, pytest-django, factory_boy added to requirements.txt