### PR TITLE
fix: replace inaccurate copyright footer with AGPL notice (#109)

### DIFF
--- a/novelapp/core/templates/base.html
+++ b/novelapp/core/templates/base.html
@@ -91,8 +91,14 @@
     </main>
 
     <footer class="mt-auto border-t border-slate-200 py-8 bg-white">
-        <div class="max-w-7xl mx-auto px-4 text-center text-slate-500 text-sm">
-            &copy; 2026 Novel It. All rights reserved.
+        <div class="max-w-7xl mx-auto px-4 text-center text-slate-500 text-sm space-y-1">
+            <p>&copy; 2026 David Hollingworth. This program comes with ABSOLUTELY NO WARRANTY.</p>
+            <p>
+                This is free software, and you are welcome to redistribute it under the terms of the
+                GNU Affero General Public License (AGPL)
+                <a href="https://www.gnu.org/licenses/agpl-3.0.html" class="underline hover:text-indigo-600" target="_blank" rel="noopener">v3</a>.
+                <a href="https://github.com/david-hollingworth/novel-it" class="underline hover:text-indigo-600" target="_blank" rel="noopener">View Source</a>
+            </p>
         </div>
     </footer>
     {% block extra_scripts %}{% endblock %}


### PR DESCRIPTION
Previous footer read '© 2026 Novel It. All rights reserved.' -- directly contradicting the AGPL license, which grants extensive rights rather than reserving all of them. New footer satisfies AGPL Section 5(d)'s Appropriate Legal Notices (copyright, no-warranty statement, redistribution notice, license link) and Section 13's source-code access requirement, in one footer since both point to the same two links.