### PR TITLE
test(novels): convert scene archive/restore/delete scenarios for Run 3

### DIFF
--- a/novelapp/novels/test_scene.py
+++ b/novelapp/novels/test_scene.py
@@ -1,15 +1,18 @@
 """
-Backend/state tests for Scene create/edit/relocate, converted from
-content/requirements/02-novel-management.md per
-data/requirements/phase-1-run-2-scope.yaml.
+Backend/state tests for Scene create/edit/relocate/archive/restore/delete,
+converted from content/requirements/02-novel-management.md.
 
-Covers the "Scene" sub-batch: T-FUNC-0223.01.01 through T-FUNC-0228.01.01
-(6 tests). Scene archive/restore/delete (T-FUNC-0225/0226/0227) are excluded
-from Run 2 -- not yet implemented -- so they're not covered here.
+The first 6 tests (create/edit/relocate) were converted per
+data/requirements/phase-1-run-2-scope.yaml for Run 2. The archive/restore/
+delete tests (T-FUNC-0225/0226/0227) were added for Run 3 -- these were
+originally excluded from Run 2 on the assumption that scene archive/restore/
+delete weren't implemented, but that assumption was wrong: the backend
+views existed all along, only the UI buttons to reach them were missing
+from the old card design. See data/requirements/phase-1-run-3-scope.yaml.
 
 Each test carries a @pytest.mark.trace(...) tag mapping it back to its
 requirements-doc test ID -- see conftest.py for how this surfaces in -v
-output, and data/requirements/phase-1-run-2-scope.yaml for the full scope.
+output.
 """
 import json
 
@@ -142,3 +145,121 @@ def test_relocate_scene_to_another_chapter(auth_client, user):
     assert response.json()['status'] == 'success'
     assert scene.chapter == target_chapter
     assert scene not in source_chapter.scenes.all()
+
+
+# T-FUNC-0225.01.01
+@pytest.mark.trace("T-FUNC-0225.01.01")
+@pytest.mark.django_db
+def test_archive_scene_success(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, archived=False)
+
+    response = auth_client.post(
+        reverse('scene_archive', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    scene.refresh_from_db()
+    assert response.status_code == 302
+    assert response.url == reverse(
+        'chapter_detail', kwargs={'novel_pk': novel.pk, 'chapter_pk': chapter.pk})
+    assert scene.archived is True
+
+    detail_response = auth_client.get(
+        reverse('chapter_detail', kwargs={'novel_pk': novel.pk, 'chapter_pk': chapter.pk}))
+    assert scene not in detail_response.context['scenes']
+
+
+# T-FUNC-0225.01.02
+@pytest.mark.trace("T-FUNC-0225.01.02")
+@pytest.mark.django_db
+def test_cancel_archiving_scene_leaves_it_unarchived(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, archived=False)
+
+    response = auth_client.get(
+        reverse('scene_archive', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    scene.refresh_from_db()
+    assert response.status_code == 200
+    assert scene.archived is False
+
+
+# T-FUNC-0226.01.01
+@pytest.mark.trace("T-FUNC-0226.01.01")
+@pytest.mark.django_db
+def test_restore_scene_success(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, archived=True)
+
+    response = auth_client.post(
+        reverse('scene_restore', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    scene.refresh_from_db()
+    assert response.status_code == 302
+    assert response.url == reverse(
+        'chapter_detail', kwargs={'novel_pk': novel.pk, 'chapter_pk': chapter.pk})
+    assert scene.archived is False
+
+    detail_response = auth_client.get(
+        reverse('chapter_detail', kwargs={'novel_pk': novel.pk, 'chapter_pk': chapter.pk}))
+    assert scene in detail_response.context['scenes']
+    archived_response = auth_client.get(
+        reverse('archived_scene_list', kwargs={'novel_pk': novel.pk, 'chapter_pk': chapter.pk}))
+    assert scene not in archived_response.context['scenes']
+
+
+# T-FUNC-0226.01.02
+@pytest.mark.trace("T-FUNC-0226.01.02")
+@pytest.mark.django_db
+def test_cancel_unarchiving_scene_leaves_it_archived(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, archived=True)
+
+    response = auth_client.get(
+        reverse('scene_restore', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    scene.refresh_from_db()
+    assert response.status_code == 200
+    assert scene.archived is True
+
+
+# T-FUNC-0227.01.01
+@pytest.mark.trace("T-FUNC-0227.01.01")
+@pytest.mark.django_db
+def test_delete_scene_success(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter)
+    scene_pk = scene.pk
+
+    response = auth_client.post(
+        reverse('scene_delete', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    assert response.status_code == 302
+    assert response.url == reverse(
+        'chapter_detail', kwargs={'novel_pk': novel.pk, 'chapter_pk': chapter.pk})
+    assert not Scene.objects.filter(pk=scene_pk).exists()
+
+
+# T-FUNC-0227.01.02
+@pytest.mark.trace("T-FUNC-0227.01.02")
+@pytest.mark.django_db
+def test_cancel_deleting_scene_leaves_it_intact(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter)
+
+    response = auth_client.get(
+        reverse('scene_delete', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    assert response.status_code == 200
+    assert Scene.objects.filter(pk=scene.pk).exists()

--- a/novelapp/novels/test_word_count_cascade.py
+++ b/novelapp/novels/test_word_count_cascade.py
@@ -1,20 +1,27 @@
 """
 Backend/state tests for word-count save/cascade behaviour, converted from
-content/requirements/03-writing-interface.md per
-data/requirements/phase-1-run-2-scope.yaml.
+content/requirements/03-writing-interface.md.
 
-Covers 12 of writing-interface's 16 backend_state tests: T-FUNC-0304.02.01
-through T-FUNC-0304.05.06 (the .01-.03 scene-level cascade tests in each of
-0304.03/.04/.05 are excluded -- scene archive/restore/delete isn't
-implemented yet).
+The chapter/part-level tests (T-FUNC-0304.02.01 through .03, and the .04-.06
+variants of 0304.03/.04/.05) were converted per
+data/requirements/phase-1-run-2-scope.yaml for Run 2. The scene-level
+cascade tests (T-FUNC-0304.03.01-03, 0304.04.01-03, 0304.05.01-03) were
+added for Run 3 -- these were originally excluded from Run 2 on the
+assumption that scene archive/restore/delete weren't implemented, but that
+assumption was wrong: the backend views existed all along, only the UI
+buttons to reach them were missing from the old card design. See
+data/requirements/phase-1-run-3-scope.yaml.
 
 Cascade chain (see novels/models.py): Scene.save() always recalculates its
 own word_count and calls chapter.update_word_count(), which recalculates
 and calls part.update_word_count(), which recalculates and calls
-novel.update_word_count(). Archiving/restoring/deleting a chapter or part
-doesn't go through Scene.save(), so each view explicitly re-triggers the
-relevant update_word_count() call -- these tests check that it actually
-does, and does so correctly.
+novel.update_word_count(). Archiving/restoring a scene goes through
+Scene.save() (so the cascade is automatic); deleting a scene doesn't, so
+scene_delete_view explicitly calls chapter.update_word_count() afterward.
+Archiving/restoring/deleting a chapter or part doesn't go through
+Scene.save() either, so those views each explicitly re-trigger the relevant
+update_word_count() call -- these tests check that all of this actually
+happens, and happens correctly.
 """
 import pytest
 from django.urls import reverse
@@ -92,6 +99,60 @@ def test_part_word_count_updates_on_scene_save_when_parts_enabled(auth_client, u
     assert part.word_count == 5
 
 
+# T-FUNC-0304.03.01
+@pytest.mark.trace("T-FUNC-0304.03.01")
+@pytest.mark.django_db
+def test_archiving_scene_reduces_chapter_word_count(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, content='one two three four five')
+    chapter.refresh_from_db()
+    assert chapter.word_count == 5
+
+    auth_client.post(
+        reverse('scene_archive', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    chapter.refresh_from_db()
+    assert chapter.word_count == 0
+
+
+# T-FUNC-0304.03.02
+@pytest.mark.trace("T-FUNC-0304.03.02")
+@pytest.mark.django_db
+def test_archiving_scene_reduces_novel_word_count(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, content='one two three four five')
+    novel.refresh_from_db()
+    assert novel.word_count == 5
+
+    auth_client.post(
+        reverse('scene_archive', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    novel.refresh_from_db()
+    assert novel.word_count == 0
+
+
+# T-FUNC-0304.03.03
+@pytest.mark.trace("T-FUNC-0304.03.03")
+@pytest.mark.django_db
+def test_archiving_scene_reduces_part_word_count_when_parts_enabled(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=True)
+    part = PartFactory(novel=novel)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, content='one two three four five')
+    part.refresh_from_db()
+    assert part.word_count == 5
+
+    auth_client.post(
+        reverse('scene_archive', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    part.refresh_from_db()
+    assert part.word_count == 0
+
+
 # T-FUNC-0304.03.04
 @pytest.mark.trace("T-FUNC-0304.03.04")
 @pytest.mark.django_db
@@ -145,6 +206,61 @@ def test_archiving_part_reduces_novel_word_count(auth_client, user):
     assert novel.word_count == 0
 
 
+# T-FUNC-0304.04.01
+@pytest.mark.trace("T-FUNC-0304.04.01")
+@pytest.mark.django_db
+def test_unarchiving_scene_increases_chapter_word_count(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, content='one two three four five', archived=True)
+    chapter.refresh_from_db()
+    # Scene is archived, so its word count doesn't count toward the chapter yet
+    assert chapter.word_count == 0
+
+    auth_client.post(
+        reverse('scene_restore', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    chapter.refresh_from_db()
+    assert chapter.word_count == 5
+
+
+# T-FUNC-0304.04.02
+@pytest.mark.trace("T-FUNC-0304.04.02")
+@pytest.mark.django_db
+def test_unarchiving_scene_increases_novel_word_count(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, content='one two three four five', archived=True)
+    novel.refresh_from_db()
+    assert novel.word_count == 0
+
+    auth_client.post(
+        reverse('scene_restore', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    novel.refresh_from_db()
+    assert novel.word_count == 5
+
+
+# T-FUNC-0304.04.03
+@pytest.mark.trace("T-FUNC-0304.04.03")
+@pytest.mark.django_db
+def test_unarchiving_scene_increases_part_word_count_when_parts_enabled(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=True)
+    part = PartFactory(novel=novel)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, content='one two three four five', archived=True)
+    part.refresh_from_db()
+    assert part.word_count == 0
+
+    auth_client.post(
+        reverse('scene_restore', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    part.refresh_from_db()
+    assert part.word_count == 5
+
+
 # T-FUNC-0304.04.04
 @pytest.mark.trace("T-FUNC-0304.04.04")
 @pytest.mark.django_db
@@ -196,6 +312,60 @@ def test_unarchiving_part_increases_novel_word_count(auth_client, user):
         reverse('part_unarchive', kwargs={'novel_pk': novel.pk, 'part_pk': part.pk}))
     novel.refresh_from_db()
     assert novel.word_count == 5
+
+
+# T-FUNC-0304.05.01
+@pytest.mark.trace("T-FUNC-0304.05.01")
+@pytest.mark.django_db
+def test_deleting_scene_reduces_chapter_word_count(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, content='one two three four five')
+    chapter.refresh_from_db()
+    assert chapter.word_count == 5
+
+    auth_client.post(
+        reverse('scene_delete', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    chapter.refresh_from_db()
+    assert chapter.word_count == 0
+
+
+# T-FUNC-0304.05.02
+@pytest.mark.trace("T-FUNC-0304.05.02")
+@pytest.mark.django_db
+def test_deleting_scene_reduces_novel_word_count(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=False)
+    part = Part.objects.create(novel=novel, title='_default', order=0)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, content='one two three four five')
+    novel.refresh_from_db()
+    assert novel.word_count == 5
+
+    auth_client.post(
+        reverse('scene_delete', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    novel.refresh_from_db()
+    assert novel.word_count == 0
+
+
+# T-FUNC-0304.05.03
+@pytest.mark.trace("T-FUNC-0304.05.03")
+@pytest.mark.django_db
+def test_deleting_scene_reduces_part_word_count_when_parts_enabled(auth_client, user):
+    novel = NovelFactory(user=user, parts_enabled=True)
+    part = PartFactory(novel=novel)
+    chapter = ChapterFactory(part=part)
+    scene = SceneFactory(chapter=chapter, content='one two three four five')
+    part.refresh_from_db()
+    assert part.word_count == 5
+
+    auth_client.post(
+        reverse('scene_delete', kwargs={
+            'novel_pk': novel.pk, 'chapter_pk': chapter.pk, 'scene_pk': scene.pk}))
+    part.refresh_from_db()
+    assert part.word_count == 0
 
 
 # T-FUNC-0304.05.04


### PR DESCRIPTION
- 6 tests: T-FUNC-0225.01.01/.02, 0226.01.01/.02, 0227.01.01/.02
- 9 word-count cascade tests: T-FUNC-0304.03.01-03, 0304.04.01-03, 0304.05.01-03
- these were excluded from Run 2 on the wrong assumption that scene archive/restore/delete weren't implemented; the views existed all along, only the UI buttons to reach them were missing
- see data/requirements/phase-1-run-3-scope.yaml