### PR TITLE
chore: add Jenkins pipeline for automated pytest runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,64 @@
+pipeline {
+    agent any
+
+    options {
+        timeout(time: 20, unit: 'MINUTES')
+    }
+
+    triggers {
+        pollSCM('H/5 * * * *')
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Set up virtualenv') {
+            steps {
+                dir('novelapp') {
+                    sh '''
+                        test -d venv || python3 -m venv venv
+                        . venv/bin/activate
+                        pip install --upgrade pip
+                        pip install -r requirements.txt
+                    '''
+                }
+            }
+        }
+
+        stage('Install Playwright browser') {
+            steps {
+                dir('novelapp') {
+                    sh '''
+                        . venv/bin/activate
+                        playwright install chromium
+                    '''
+                }
+            }
+        }
+
+        stage('Run tests') {
+            steps {
+                dir('novelapp') {
+                    withCredentials([string(credentialsId: 'novelit-database-url', variable: 'DATABASE_URL')]) {
+                        sh '''
+                            . venv/bin/activate
+                            pytest -v --junitxml=results.xml
+                        '''
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            dir('novelapp') {
+                junit 'results.xml'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Polls SCM every 5 minutes. Fresh venv + Playwright browser cache persist across builds rather than reinstalling from scratch each run. DATABASE_URL is injected via Jenkins credentials, never stored in the repo. Results published via JUnit plugin from pytest's --junitxml output.

CI only runs pytest and reports pass/fail -- it does not touch novel-it-docs or trace_report.py. Official numbered test runs stay a deliberate manual process (see the Trilium runbook).